### PR TITLE
Config flag

### DIFF
--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"testing"
+)
+
+// TestSCStarts will start a sc tunnel if the $SAUCE_USERNAME and $SAUCE_ACCESS_KEY environment variables are set with valid data
+func TestBadConfigs(t *testing.T) {
+	if configUsable("") != false {
+		t.Fail()
+	}
+
+	if configUsable(" ") != false {
+		t.Fail()
+	}
+
+	if configUsable("bad file path") != false {
+		t.Fail()
+	}
+
+	if configUsable("/path/to/non-existent/file.txt") != false {
+		t.Fail()
+	}
+}


### PR DESCRIPTION

    - check for empty string i.e. no -c or --config used
    - check that the os can find a real file
    - check that the file is reachable
    - check that the file is a directory
