### PR TITLE
Refactor and comment

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -64,7 +64,6 @@ var startCmd = &cobra.Command{
 			}
 		}
 		wg.Wait()
-		logger.Disklog.Info("According to statefile all tunnels are closed.  Goodbye :)")
 	},
 }
 

--- a/manager/balancer.go
+++ b/manager/balancer.go
@@ -16,7 +16,7 @@ func balance(lastState []Tunnel, pool string) int {
 	return count
 }
 
-func startTunnel(config Metadata) bool {
+func vacancy(config Metadata) bool {
 	state := getLastKnownState()
 	curBal := balance(state.Tunnels, config.Pool)
 	if curBal < config.Size {

--- a/manager/parser.go
+++ b/manager/parser.go
@@ -1,0 +1,11 @@
+package manager
+
+import "strings"
+
+func eatLine(line string) bool {
+	// Comment symbol
+	if line == "#" || line == "# " || strings.HasPrefix(line, "#") {
+		return true
+	}
+	return false
+}

--- a/manager/state.go
+++ b/manager/state.go
@@ -67,6 +67,7 @@ func RemoveTunnel(targetPID int) {
 	state := getLastKnownState()
 	for i := 0; i < len(state.Tunnels); i++ {
 		tunnel := state.Tunnels[i]
+		logger.Disklog.Infof("Closing Tunnel %s", tunnel.Args)
 		if tunnel.PID == targetPID {
 			state.Tunnels = append(state.Tunnels[:i], state.Tunnels[i+1:]...)
 			break

--- a/manager/tunnel_unix.go
+++ b/manager/tunnel_unix.go
@@ -4,7 +4,6 @@ package manager
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -19,8 +18,7 @@ func Start(launchArgs string, wg *sync.WaitGroup, meta Metadata) {
 	args := strings.Split(launchArgs, " ")
 	path := args[0]
 
-	if path == "#" || strings.Contains(path, "#") {
-		fmt.Println("path we're using here>>>>>>>>>>>>", path)
+	if eatLine(path) {
 		return
 	}
 
@@ -52,7 +50,6 @@ func Start(launchArgs string, wg *sync.WaitGroup, meta Metadata) {
 			AddTunnel(launchArgs, path, scCmd.Process.Pid, meta, tunLog)
 		}
 	}
-	logger.Disklog.Debugf("Tunnel %s closed", launchArgs)
 	defer scCmd.Wait()
 }
 

--- a/manager/tunnel_unix.go
+++ b/manager/tunnel_unix.go
@@ -4,6 +4,7 @@ package manager
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -17,6 +18,11 @@ func Start(launchArgs string, wg *sync.WaitGroup, meta Metadata) {
 	defer wg.Done()
 	args := strings.Split(launchArgs, " ")
 	path := args[0]
+
+	if path == "#" || strings.Contains(path, "#") {
+		fmt.Println("path we're using here>>>>>>>>>>>>", path)
+		return
+	}
 
 	if vacancy(meta) != true {
 		logger.Disklog.Infof("Too many tunnels open.  Not opening %s \n %v", meta.Pool, launchArgs)

--- a/manager/tunnel_unix.go
+++ b/manager/tunnel_unix.go
@@ -18,7 +18,7 @@ func Start(launchArgs string, wg *sync.WaitGroup, meta Metadata) {
 	args := strings.Split(launchArgs, " ")
 	path := args[0]
 
-	if startTunnel(meta) != true {
+	if vacancy(meta) != true {
 		logger.Disklog.Infof("Too many tunnels open.  Not opening %s \n %v", meta.Pool, launchArgs)
 		return
 	}


### PR DESCRIPTION
- Added eatLine() in parser.go for crude ability to comment in a config file with '#'
- removed redundant and annoying STDOUT output that disrupted regular terminal usage.  Cosmetic and logging changes