### PR TITLE
Add tunnelid

### DIFF
--- a/cmd/show.go
+++ b/cmd/show.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"github.com/mdsauce/sauced/logger"
 	"github.com/mdsauce/sauced/manager"
+	"github.com/mdsauce/sauced/output"
 
 	"github.com/spf13/cobra"
 )
@@ -29,7 +30,7 @@ var showCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logger.Disklog.Debug("show called by the user.  Pruning then listing all tunnels.")
 		manager.PruneState()
-		manager.ShowStateJSON()
+		output.ShowStateJSON()
 	},
 }
 

--- a/manager/balancer.go
+++ b/manager/balancer.go
@@ -17,7 +17,7 @@ func balance(lastState []Tunnel, pool string) int {
 }
 
 func vacancy(config Metadata) bool {
-	state := getLastKnownState()
+	state := GetLastKnownState()
 	curBal := balance(state.Tunnels, config.Pool)
 	if curBal < config.Size {
 		return true

--- a/manager/state.go
+++ b/manager/state.go
@@ -142,8 +142,7 @@ func UpdateState(newMeta map[string]Metadata) {
 	}
 }
 
-// GetLastKnownState will retrieve a byte[] slice with the contents
-// of the /tmp/sauced-stat.json file
+// GetLastKnownState will retrieve a byte[] slice with the contents of the sauced-state.json file
 func GetLastKnownState() LastKnownTunnels {
 	rawValue, err := ioutil.ReadFile("/tmp/sauced-state.json")
 	if err != nil {

--- a/manager/state.go
+++ b/manager/state.go
@@ -65,7 +65,7 @@ func AddTunnel(launchArgs string, path string, PID int, meta Metadata, tunnelLog
 // RemoveTunnel deletes a tunnel entry from the
 // Last Known Tunnel object
 func RemoveTunnel(targetPID int) {
-	state := getLastKnownState()
+	state := GetLastKnownState()
 	for i := 0; i < len(state.Tunnels); i++ {
 		tunnel := state.Tunnels[i]
 		logger.Disklog.Infof("Closing Tunnel %s", tunnel.Args)
@@ -87,7 +87,7 @@ func RemoveTunnel(targetPID int) {
 // PruneState will access the state file and
 // remove any entries that are not found by the OS
 func PruneState() {
-	state := getLastKnownState()
+	state := GetLastKnownState()
 	for i := 0; i < len(state.Tunnels); i++ {
 		tunnel := state.Tunnels[i]
 		proc, _ := os.FindProcess(tunnel.PID)
@@ -119,7 +119,7 @@ func PruneState() {
 // UpdateState uses the derived metadata
 // to correct the statefile
 func UpdateState(newMeta map[string]Metadata) {
-	newState := getLastKnownState()
+	newState := GetLastKnownState()
 	// loop through the lastknownstate and update the .metadata based on the newMeta.
 	for index, tunnel := range newState.Tunnels {
 		oldMeta := tunnel.Metadata
@@ -142,26 +142,12 @@ func UpdateState(newMeta map[string]Metadata) {
 	}
 }
 
-// ShowState will list all the known tunnels
-func ShowState() {
-	last := getLastKnownState()
-	logger.Disklog.Info(last)
-}
-
-// ShowStateJSON will pretty print JSON
-func ShowStateJSON() {
-	last := getLastKnownState()
-	lastJSON, err := json.MarshalIndent(last, "", "    ")
-	if err != nil {
-		logger.Disklog.Warnf("Could not format JSON with Indents: %v", err)
-	}
-	logger.Disklog.Info(string(lastJSON))
-}
-
-func getLastKnownState() LastKnownTunnels {
+// GetLastKnownState will retrieve a byte[] slice with the contents
+// of the /tmp/sauced-stat.json file
+func GetLastKnownState() LastKnownTunnels {
 	rawValue, err := ioutil.ReadFile("/tmp/sauced-state.json")
 	if err != nil {
-		logger.Disklog.Warn("Could notget last known state from file: ", err)
+		logger.Disklog.Warn("Could not get last known state from file: ", err)
 	}
 	var tunnelsState LastKnownTunnels
 

--- a/manager/state.go
+++ b/manager/state.go
@@ -20,6 +20,7 @@ type LastKnownTunnels struct {
 // of an OS process after SC has launched
 type Tunnel struct {
 	PID        int       `json:"pid"`
+	AssignedID string    `json:"assignedID"`
 	SCBinary   string    `json:"scbinary"`
 	Args       string    `json:"args"`
 	LaunchTime time.Time `json:"launchtime"`
@@ -34,11 +35,11 @@ type Tunnel struct {
 
 // AddTunnel will record the state of the tunnel
 // to the IPC file after the tunnel has launched as an OS process
-func AddTunnel(launchArgs string, path string, PID int, meta Metadata, tunnelLog string) {
+func AddTunnel(launchArgs string, path string, PID int, meta Metadata, tunnelLog string, asgnID string) {
 	createIPCFile()
 
 	var tunnelsState LastKnownTunnels
-	tun := Tunnel{PID, path, launchArgs, time.Now().UTC(), tunnelLog, meta}
+	tun := Tunnel{PID, asgnID, path, launchArgs, time.Now().UTC(), tunnelLog, meta}
 
 	rawValue, err := ioutil.ReadFile("/tmp/sauced-state.json")
 	if err != nil {

--- a/manager/tunnel_test.go
+++ b/manager/tunnel_test.go
@@ -27,7 +27,7 @@ func TestSCFailsOnBadInput(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go Start(scBinary, &wg, Metadata{})
-	tunnels := getLastKnownState()
+	tunnels := GetLastKnownState()
 	if len(tunnels.Tunnels) != 0 {
 		t.Fail()
 	}

--- a/manager/tunnel_unix.go
+++ b/manager/tunnel_unix.go
@@ -83,7 +83,7 @@ func Stop(Pid int) {
 // StopAll will send a kill or SIGINT signal
 // to all tunnels that are running.
 func StopAll() {
-	last := getLastKnownState()
+	last := GetLastKnownState()
 	for _, tunnel := range last.Tunnels {
 		Stop(tunnel.PID)
 	}

--- a/manager/tunnel_unix.go
+++ b/manager/tunnel_unix.go
@@ -38,16 +38,26 @@ func Start(launchArgs string, wg *sync.WaitGroup, meta Metadata) {
 	scanner := bufio.NewScanner(stdout)
 	scanner.Split(bufio.ScanLines)
 
+	// this parsing should be moved to its own funciton.
+	// everything should be parsed then supplied to the AddTunnel() func
 	var tunLog string
+	var asgnID string
 	for scanner.Scan() {
 		m := scanner.Text()
+		// should be a func that is unit tested
 		if strings.Contains(m, "Log file:") {
 			ll := strings.Split(m, " ")
 			tunLog = ll[len(ll)-1]
 			logger.Disklog.Infof("Tunnel log started for tunnel: %s \n %s", launchArgs, m)
 		}
+		// should be a func that is unit tested
+		if strings.Contains(m, "Tunnel ID:") {
+			idLine := strings.Split(m, " ")
+			asgnID = idLine[len(idLine)-1]
+			logger.Disklog.Infof("Tunnel: %s has AssignedID %s", launchArgs, asgnID)
+		}
 		if strings.Contains(m, "Sauce Connect is up") {
-			AddTunnel(launchArgs, path, scCmd.Process.Pid, meta, tunLog)
+			AddTunnel(launchArgs, path, scCmd.Process.Pid, meta, tunLog, asgnID)
 		}
 	}
 	defer scCmd.Wait()

--- a/output/simpleui.go
+++ b/output/simpleui.go
@@ -1,0 +1,18 @@
+package output
+
+import (
+	"encoding/json"
+
+	"github.com/mdsauce/sauced/logger"
+	"github.com/mdsauce/sauced/manager"
+)
+
+// ShowStateJSON will pretty print JSON
+func ShowStateJSON() {
+	last := manager.GetLastKnownState()
+	lastJSON, err := json.MarshalIndent(last, "", "    ")
+	if err != nil {
+		logger.Disklog.Warnf("Could not format JSON with Indents: %v", err)
+	}
+	logger.Disklog.Info(string(lastJSON))
+}


### PR DESCRIPTION
Assigned Tunnel ID is now pulled out of the tunnel's log as the tunnel starts.  Once the Tunnel is up it is passed to `AddTunnel()`.