### PR TITLE
Show tunnels by pool name and tunnel ID

### DIFF
--- a/cmd/show.go
+++ b/cmd/show.go
@@ -49,7 +49,7 @@ var showCmd = &cobra.Command{
 		} else if pool == "" && id == "" {
 			output.ShowStateJSON()
 		} else {
-			manager.ShowPool(pool)
+			output.ShowPool(pool)
 		}
 
 	},

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -39,8 +39,14 @@ var showCmd = &cobra.Command{
 		manager.PruneState()
 
 		pool, _ := cmd.Flags().GetString("pool")
+		id, _ := cmd.Flags().GetString("id")
+
 		logger.Disklog.Debug("Pool name searched: ", pool)
-		if pool == "" {
+		logger.Disklog.Debug("ID searched: ", id)
+
+		if pool == "" && id != "" {
+			manager.ShowTunnel(id)
+		} else if pool == "" && id == "" {
 			output.ShowStateJSON()
 		} else {
 			manager.ShowPool(pool)
@@ -62,5 +68,7 @@ func init() {
 	// is called directly, e.g.:
 	// showCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 
-	showCmd.Flags().String("pool", "", "Pool name of tunnels. May return one or more results.")
+	showCmd.Flags().String("pool", "", "Pool name of tunnels. May return one or more results. Takes precedence over --id")
+	showCmd.Flags().String("id", "", "Assigned ID for a given tunnel.")
+
 }

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -28,11 +28,18 @@ var showCmd = &cobra.Command{
 	Short: "List all last known tunnels.",
 	Long:  `The tunnel state list will be pruned and then all active tunnels will be shown.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		logger.Disklog.Info("show called by the user. Pruning then listing all tunnels.")
+		//TODO: This should be it's function since it's called on all files.
+		logfile, err := cmd.Flags().GetString("logfile")
+		if err != nil {
+			logger.Disklog.Warn("Problem retrieving logfile flag", err)
+		}
+		logger.SetupLogfile(logfile)
+
+		logger.Disklog.Debug("show called by the user. Pruning then listing all tunnels.")
 		manager.PruneState()
 
 		pool, _ := cmd.Flags().GetString("pool")
-		logger.Disklog.Info("Pool name searched: ", pool)
+		logger.Disklog.Debug("Pool name searched: ", pool)
 		if pool == "" {
 			output.ShowStateJSON()
 		} else {

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -28,9 +28,17 @@ var showCmd = &cobra.Command{
 	Short: "List all last known tunnels.",
 	Long:  `The tunnel state list will be pruned and then all active tunnels will be shown.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		logger.Disklog.Debug("show called by the user.  Pruning then listing all tunnels.")
+		logger.Disklog.Info("show called by the user. Pruning then listing all tunnels.")
 		manager.PruneState()
-		output.ShowStateJSON()
+
+		pool, _ := cmd.Flags().GetString("pool")
+		logger.Disklog.Info("Pool name searched: ", pool)
+		if pool == "" {
+			output.ShowStateJSON()
+		} else {
+			manager.ShowPool(pool)
+		}
+
 	},
 }
 
@@ -46,4 +54,6 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// showCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+	showCmd.Flags().String("pool", "", "Pool name of tunnels. May return one or more results.")
 }

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -45,7 +45,7 @@ var showCmd = &cobra.Command{
 		logger.Disklog.Debug("ID searched: ", id)
 
 		if pool == "" && id != "" {
-			manager.ShowTunnel(id)
+			output.ShowTunnelJSON(id)
 		} else if pool == "" && id == "" {
 			output.ShowStateJSON()
 		} else {

--- a/manager/state.go
+++ b/manager/state.go
@@ -34,6 +34,7 @@ type Tunnel struct {
 // 	return nil
 // }
 
+// FindTunnelByPID gets a PID int and finds a given tunnel
 func (tState LastKnownTunnels) FindTunnelByPID(targetPID int) (Tunnel, error) {
 	var tunnel Tunnel
 	for i := 0; i < len(tState.Tunnels); i++ {
@@ -46,6 +47,7 @@ func (tState LastKnownTunnels) FindTunnelByPID(targetPID int) (Tunnel, error) {
 	return tunnel, errors.New("No tunnel found with given PID")
 }
 
+// FindTunnelsByPool gets a pool name and returns a list of tunnels
 func (tState LastKnownTunnels) FindTunnelsByPool(poolName string) ([]Tunnel, error) {
 	var tunnel Tunnel
 	tunnels := make([]Tunnel, 0)
@@ -63,6 +65,7 @@ func (tState LastKnownTunnels) FindTunnelsByPool(poolName string) ([]Tunnel, err
 	return tunnels, nil
 }
 
+// FindTunnelsByID gets a tunnel ID and returns a tunnel
 func (tState LastKnownTunnels) FindTunnelsByID(assignedID string) (Tunnel, error) {
 	var tunnel Tunnel
 	for i := 0; i < len(tState.Tunnels); i++ {

--- a/manager/state.go
+++ b/manager/state.go
@@ -36,28 +36,9 @@ type Tunnel struct {
 
 // ShowPool is in charge getting state and searching for a pool of tunnels
 func ShowPool(poolName string) {
-	var tstate LastKnownTunnels
-	tstate = GetLastKnownState()
+	tstate := GetLastKnownState()
 
-	tunnels, err := tstate.findTunnelsByPool(poolName)
-
-	if err != nil {
-		logger.Disklog.Info(err)
-	} else {
-		tunnelsJSON, err := json.MarshalIndent(tunnels, "", "    ")
-		if err != nil {
-			logger.Disklog.Warnf("Could not format JSON with Indents: %v", err)
-		}
-		logger.Disklog.Info(string(tunnelsJSON))
-	}
-}
-
-// ShowTunnel is in charge getting state and searching for a single tunnel by ID.
-func ShowTunnel(assignedID string) {
-	var tstate LastKnownTunnels
-	tstate = GetLastKnownState()
-
-	tunnels, err := tstate.findTunnelsByID(assignedID)
+	tunnels, err := tstate.FindTunnelsByPool(poolName)
 
 	if err != nil {
 		logger.Disklog.Info(err)
@@ -70,7 +51,7 @@ func ShowTunnel(assignedID string) {
 	}
 }
 
-func (tState LastKnownTunnels) findTunnelByPID(targetPID int) (Tunnel, error) {
+func (tState LastKnownTunnels) FindTunnelByPID(targetPID int) (Tunnel, error) {
 	var tunnel Tunnel
 	for i := 0; i < len(tState.Tunnels); i++ {
 		tunnel = tState.Tunnels[i]
@@ -82,7 +63,7 @@ func (tState LastKnownTunnels) findTunnelByPID(targetPID int) (Tunnel, error) {
 	return tunnel, errors.New("No tunnel found with given PID")
 }
 
-func (tState LastKnownTunnels) findTunnelsByPool(poolName string) ([]Tunnel, error) {
+func (tState LastKnownTunnels) FindTunnelsByPool(poolName string) ([]Tunnel, error) {
 	var tunnel Tunnel
 	tunnels := make([]Tunnel, 0)
 	for i := 0; i < len(tState.Tunnels); i++ {
@@ -99,7 +80,7 @@ func (tState LastKnownTunnels) findTunnelsByPool(poolName string) ([]Tunnel, err
 	return tunnels, nil
 }
 
-func (tState LastKnownTunnels) findTunnelsByID(assignedID string) (Tunnel, error) {
+func (tState LastKnownTunnels) FindTunnelsByID(assignedID string) (Tunnel, error) {
 	var tunnel Tunnel
 	for i := 0; i < len(tState.Tunnels); i++ {
 		tunnel = tState.Tunnels[i]

--- a/manager/state.go
+++ b/manager/state.go
@@ -34,23 +34,6 @@ type Tunnel struct {
 // 	return nil
 // }
 
-// ShowPool is in charge getting state and searching for a pool of tunnels
-func ShowPool(poolName string) {
-	tstate := GetLastKnownState()
-
-	tunnels, err := tstate.FindTunnelsByPool(poolName)
-
-	if err != nil {
-		logger.Disklog.Info(err)
-	} else {
-		tunnelsJSON, err := json.MarshalIndent(tunnels, "", "    ")
-		if err != nil {
-			logger.Disklog.Warnf("Could not format JSON with Indents: %v", err)
-		}
-		logger.Disklog.Info(string(tunnelsJSON))
-	}
-}
-
 func (tState LastKnownTunnels) FindTunnelByPID(targetPID int) (Tunnel, error) {
 	var tunnel Tunnel
 	for i := 0; i < len(tState.Tunnels); i++ {

--- a/manager/state.go
+++ b/manager/state.go
@@ -52,6 +52,24 @@ func ShowPool(poolName string) {
 	}
 }
 
+// ShowTunnel is in charge getting state and searching for a single tunnel by ID.
+func ShowTunnel(assignedID string) {
+	var tstate LastKnownTunnels
+	tstate = GetLastKnownState()
+
+	tunnels, err := tstate.findTunnelsByID(assignedID)
+
+	if err != nil {
+		logger.Disklog.Info(err)
+	} else {
+		tunnelsJSON, err := json.MarshalIndent(tunnels, "", "    ")
+		if err != nil {
+			logger.Disklog.Warnf("Could not format JSON with Indents: %v", err)
+		}
+		logger.Disklog.Info(string(tunnelsJSON))
+	}
+}
+
 func (tState LastKnownTunnels) findTunnelByPID(targetPID int) (Tunnel, error) {
 	var tunnel Tunnel
 	for i := 0; i < len(tState.Tunnels); i++ {
@@ -79,6 +97,20 @@ func (tState LastKnownTunnels) findTunnelsByPool(poolName string) ([]Tunnel, err
 		return tunnels, errors.New("No tunnel found with given Pool name")
 	}
 	return tunnels, nil
+}
+
+func (tState LastKnownTunnels) findTunnelsByID(assignedID string) (Tunnel, error) {
+	var tunnel Tunnel
+	for i := 0; i < len(tState.Tunnels); i++ {
+		tunnel = tState.Tunnels[i]
+		if tunnel.AssignedID == assignedID {
+			return tunnel, nil
+
+		}
+	}
+
+	return tunnel, errors.New("No tunnel found with given ID")
+
 }
 
 // AddTunnel will record the state of the tunnel

--- a/output/simpleui.go
+++ b/output/simpleui.go
@@ -33,3 +33,20 @@ func ShowTunnelJSON(assignedID string) {
 		logger.Disklog.Info(string(tunnelsJSON))
 	}
 }
+
+// ShowPool is in charge getting state and searching for a pool of tunnels
+func ShowPool(poolName string) {
+	tstate := manager.GetLastKnownState()
+
+	tunnels, err := tstate.FindTunnelsByPool(poolName)
+
+	if err != nil {
+		logger.Disklog.Info(err)
+	} else {
+		tunnelsJSON, err := json.MarshalIndent(tunnels, "", "    ")
+		if err != nil {
+			logger.Disklog.Warnf("Could not format JSON with Indents: %v", err)
+		}
+		logger.Disklog.Info(string(tunnelsJSON))
+	}
+}

--- a/output/simpleui.go
+++ b/output/simpleui.go
@@ -16,3 +16,20 @@ func ShowStateJSON() {
 	}
 	logger.Disklog.Info(string(lastJSON))
 }
+
+// ShowTunnelJSON is in charge getting state and searching for a single tunnel by ID.
+func ShowTunnelJSON(assignedID string) {
+	tstate := manager.GetLastKnownState()
+
+	tunnels, err := tstate.FindTunnelsByID(assignedID)
+
+	if err != nil {
+		logger.Disklog.Info(err)
+	} else {
+		tunnelsJSON, err := json.MarshalIndent(tunnels, "", "    ")
+		if err != nil {
+			logger.Disklog.Warnf("Could not format JSON with Indents: %v", err)
+		}
+		logger.Disklog.Info(string(tunnelsJSON))
+	}
+}


### PR DESCRIPTION
These changes make it possible to find a tunnel or tunnels either by the assigned ID or by their tunnel identifier/pool name.

Takes care of #48 and #49 

This can be done like:
```bash
sauced show --pool my-sample-tunnel
```
or
```bash
sauced show --id 123de42d32h342
```