### PR TITLE
Stop tunnels by pool and ID

### DIFF
--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -46,19 +46,8 @@ var stopCmd = &cobra.Command{
 			manager.StopAll()
 			logger.Disklog.Info("All tunnels sent the Kill, Interrupt, or SIGINT signal.  Sauced closing.")
 		} else if pool == "" && id != "" { // id is the only one set
-			tstate := manager.GetLastKnownState()
+			manager.StopTunnelByID(id)
 
-			tunnel, err := tstate.FindTunnelByID(id)
-
-			if err != nil {
-				logger.Disklog.Info(err)
-			} else {
-				// find tunnel by ID
-				// get pid
-				// stop tunnel
-				// remove tunnel from state
-
-			}
 		} else if pool != "" { // delete pool. doesn't matter if id is set too
 			// find tunnel(s) by pool
 			// get pid(s)

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -37,22 +37,24 @@ var stopCmd = &cobra.Command{
 		id, _ := cmd.Flags().GetString("id")
 		all, _ := cmd.Flags().GetBool("all")
 
-		logger.Disklog.Debug("All flag: ", all)
-		logger.Disklog.Debug("Pool name searched: ", pool)
-		logger.Disklog.Debug("ID searched: ", id)
+		logger.Disklog.Debugf("All flag: %t", all)
+		logger.Disklog.Debugf("Pool name searched: %s", pool)
+		logger.Disklog.Debugf("ID searched: %s", id)
 
 		if all { // stop all tunnel regardless of other flags
-			logger.Disklog.Info("Stop command sent. Stopping all tunnels.")
+			logger.Disklog.Info("Stopping all tunnels.")
 			manager.StopAll()
 			logger.Disklog.Info("All tunnels sent the Kill, Interrupt, or SIGINT signal. Sauced closing.")
 		} else if pool == "" && id != "" { // id is the only one set
+			logger.Disklog.Infof("Stopping tunnel ID: %s", id)
 			manager.StopTunnelByID(id)
+			logger.Disklog.Infof("Tunnel stopped")
 
 		} else if pool != "" { // delete pool. doesn't matter if id is set too
-			// find tunnel(s) by pool
-			// get pid(s)
-			// stop tunnel(s)
-			// remove tunnel(s) from state
+			logger.Disklog.Infof("Stopping tunnel pool: %s", pool)
+			manager.StopTunnelsByPool(pool)
+			logger.Disklog.Infof("Tunnel pool stopped")
+
 		} else {
 			logger.Disklog.Error("No flag was added. Please use -h for options")
 		}

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -46,10 +46,19 @@ var stopCmd = &cobra.Command{
 			manager.StopAll()
 			logger.Disklog.Info("All tunnels sent the Kill, Interrupt, or SIGINT signal.  Sauced closing.")
 		} else if pool == "" && id != "" { // id is the only one set
-			// find tunnel by ID
-			// get pid
-			// stop tunnel
-			// remove tunnel from state
+			tstate := manager.GetLastKnownState()
+
+			tunnel, err := tstate.FindTunnelByID(id)
+
+			if err != nil {
+				logger.Disklog.Info(err)
+			} else {
+				// find tunnel by ID
+				// get pid
+				// stop tunnel
+				// remove tunnel from state
+
+			}
 		} else if pool != "" { // delete pool. doesn't matter if id is set too
 			// find tunnel(s) by pool
 			// get pid(s)

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -42,9 +42,9 @@ var stopCmd = &cobra.Command{
 		logger.Disklog.Debug("ID searched: ", id)
 
 		if all { // stop all tunnel regardless of other flags
-			logger.Disklog.Info("Stop command sent.  Stopping all tunnels.")
+			logger.Disklog.Info("Stop command sent. Stopping all tunnels.")
 			manager.StopAll()
-			logger.Disklog.Info("All tunnels sent the Kill, Interrupt, or SIGINT signal.  Sauced closing.")
+			logger.Disklog.Info("All tunnels sent the Kill, Interrupt, or SIGINT signal. Sauced closing.")
 		} else if pool == "" && id != "" { // id is the only one set
 			manager.StopTunnelByID(id)
 

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -33,10 +33,6 @@ var stopCmd = &cobra.Command{
 		}
 		logger.SetupLogfile(logfile)
 
-		logger.Disklog.Info("Stop command sent.  Stopping all tunnels.")
-		manager.StopAll()
-		logger.Disklog.Info("All tunnels sent the Kill, Interrupt, or SIGINT signal.  Sauced closing.")
-
 		pool, _ := cmd.Flags().GetString("pool")
 		id, _ := cmd.Flags().GetString("id")
 		all, _ := cmd.Flags().GetBool("all")
@@ -45,12 +41,22 @@ var stopCmd = &cobra.Command{
 		logger.Disklog.Debug("Pool name searched: ", pool)
 		logger.Disklog.Debug("ID searched: ", id)
 
-		if pool == "" && id != "" {
-
-		} else if pool == "" && id == "" {
-
+		if all { // stop all tunnel regardless of other flags
+			logger.Disklog.Info("Stop command sent.  Stopping all tunnels.")
+			manager.StopAll()
+			logger.Disklog.Info("All tunnels sent the Kill, Interrupt, or SIGINT signal.  Sauced closing.")
+		} else if pool == "" && id != "" { // id is the only one set
+			// find tunnel by ID
+			// get pid
+			// stop tunnel
+			// remove tunnel from state
+		} else if pool != "" { // delete pool. doesn't matter if id is set too
+			// find tunnel(s) by pool
+			// get pid(s)
+			// stop tunnel(s)
+			// remove tunnel(s) from state
 		} else {
-
+			logger.Disklog.Error("No flag was added. Please use -h for options")
 		}
 
 	},

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -26,6 +26,13 @@ var stopCmd = &cobra.Command{
 	Short: "Stop all running tunnels and close this program.",
 	Long:  `Use the last known tunnel state to stop all tunnels.  This process will close after SIGINT or kill signal has been deliverd to all tunnels.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		//TODO: This should be it's function since it's called on all files.
+		logfile, err := cmd.Flags().GetString("logfile")
+		if err != nil {
+			logger.Disklog.Warn("Problem retrieving logfile flag", err)
+		}
+		logger.SetupLogfile(logfile)
+
 		logger.Disklog.Info("Stop command sent.  Stopping all tunnels.")
 		manager.StopAll()
 		logger.Disklog.Info("All tunnels sent the Kill, Interrupt, or SIGINT signal.  Sauced closing.")

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -29,6 +29,23 @@ var stopCmd = &cobra.Command{
 		logger.Disklog.Info("Stop command sent.  Stopping all tunnels.")
 		manager.StopAll()
 		logger.Disklog.Info("All tunnels sent the Kill, Interrupt, or SIGINT signal.  Sauced closing.")
+
+		pool, _ := cmd.Flags().GetString("pool")
+		id, _ := cmd.Flags().GetString("id")
+		all, _ := cmd.Flags().GetBool("all")
+
+		logger.Disklog.Debug("All flag: ", all)
+		logger.Disklog.Debug("Pool name searched: ", pool)
+		logger.Disklog.Debug("ID searched: ", id)
+
+		if pool == "" && id != "" {
+
+		} else if pool == "" && id == "" {
+
+		} else {
+
+		}
+
 	},
 }
 
@@ -44,4 +61,8 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// stopCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+	stopCmd.Flags().String("pool", "", "Pool name of tunnels. May return one or more results. Takes precedence over --id")
+	stopCmd.Flags().String("id", "", "Assigned ID for a given tunnel.")
+	stopCmd.Flags().Bool("all", false, "Allows stopping all active tunnels. Takes precedence over all other flags.")
 }

--- a/manager/state.go
+++ b/manager/state.go
@@ -65,8 +65,8 @@ func (tState LastKnownTunnels) FindTunnelsByPool(poolName string) ([]Tunnel, err
 	return tunnels, nil
 }
 
-// FindTunnelsByID gets a tunnel ID and returns a tunnel
-func (tState LastKnownTunnels) FindTunnelsByID(assignedID string) (Tunnel, error) {
+// FindTunnelByID gets a tunnel ID and returns a tunnel
+func (tState LastKnownTunnels) FindTunnelByID(assignedID string) (Tunnel, error) {
 	var tunnel Tunnel
 	for i := 0; i < len(tState.Tunnels); i++ {
 		tunnel = tState.Tunnels[i]

--- a/manager/tunnel_unix.go
+++ b/manager/tunnel_unix.go
@@ -92,6 +92,21 @@ func StopTunnelByID(assignedID string) {
 	}
 
 }
+
+func StopTunnelsByPool(poolName string) {
+	tstate := GetLastKnownState()
+
+	tunnels, err := tstate.FindTunnelsByPool(poolName)
+
+	if err != nil {
+		logger.Disklog.Info(err)
+	} else {
+		for _, tunnel := range tunnels {
+			Stop(tunnel.PID)
+		}
+	}
+}
+
 // StopAll will send a kill or SIGINT signal
 // to all tunnels that are running.
 func StopAll() {

--- a/manager/tunnel_unix.go
+++ b/manager/tunnel_unix.go
@@ -75,14 +75,15 @@ func Stop(Pid int) {
 		}
 		// Only amend statefile if there wasn't an error
 		if err == nil {
+			logger.Disklog.Debugf("Removing tunnel PID %v from statefile", Pid)
 			RemoveTunnel(Pid)
 		}
 	}
 }
 
+// StopTunnelByID will stop a single tunnel that matches a given ID
 func StopTunnelByID(assignedID string) {
 	tstate := GetLastKnownState()
-
 	tunnel, err := tstate.FindTunnelByID(assignedID)
 
 	if err != nil {
@@ -93,9 +94,9 @@ func StopTunnelByID(assignedID string) {
 
 }
 
+// StopTunnelsByPool will stop a tunnel pool matching the given pool name
 func StopTunnelsByPool(poolName string) {
 	tstate := GetLastKnownState()
-
 	tunnels, err := tstate.FindTunnelsByPool(poolName)
 
 	if err != nil {

--- a/manager/tunnel_unix.go
+++ b/manager/tunnel_unix.go
@@ -80,6 +80,18 @@ func Stop(Pid int) {
 	}
 }
 
+func StopTunnelByID(assignedID string) {
+	tstate := GetLastKnownState()
+
+	tunnel, err := tstate.FindTunnelByID(assignedID)
+
+	if err != nil {
+		logger.Disklog.Info(err)
+	} else {
+		Stop(tunnel.PID)
+	}
+
+}
 // StopAll will send a kill or SIGINT signal
 // to all tunnels that are running.
 func StopAll() {

--- a/output/simpleui.go
+++ b/output/simpleui.go
@@ -21,16 +21,16 @@ func ShowStateJSON() {
 func ShowTunnelJSON(assignedID string) {
 	tstate := manager.GetLastKnownState()
 
-	tunnels, err := tstate.FindTunnelsByID(assignedID)
+	tunnel, err := tstate.FindTunnelByID(assignedID)
 
 	if err != nil {
 		logger.Disklog.Info(err)
 	} else {
-		tunnelsJSON, err := json.MarshalIndent(tunnels, "", "    ")
+		tunnelJSON, err := json.MarshalIndent(tunnel, "", "    ")
 		if err != nil {
 			logger.Disklog.Warnf("Could not format JSON with Indents: %v", err)
 		}
-		logger.Disklog.Info(string(tunnelsJSON))
+		logger.Disklog.Info(string(tunnelJSON))
 	}
 }
 


### PR DESCRIPTION
Fixes #43 and #44 

This PR adds a --pool, --id and --all flag to the stop command.
It's now possible to stop a single tunnel giving it's ID, a whole pool given the identifier it got started with or all the tunnels managed by sauced.