### PR TITLE
Pretty show

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,3 +10,4 @@ jobs:
       - run: go build -ldflags "-X github.com/mdsauce/sauced/cmd.CurVersion=`git rev-parse --short HEAD`"
       - run: ./sauced --help
       - run: ./sauced --version
+      - run: ./sauced show --pretty

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,4 +10,4 @@ jobs:
       - run: go build -ldflags "-X github.com/mdsauce/sauced/cmd.CurVersion=`git rev-parse --short HEAD`"
       - run: ./sauced --help
       - run: ./sauced --version
-      - run: ./sauced show --pretty
+      - run: ./sauced show --human

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,4 +10,6 @@ jobs:
       - run: go build -ldflags "-X github.com/mdsauce/sauced/cmd.CurVersion=`git rev-parse --short HEAD`"
       - run: ./sauced --help
       - run: ./sauced --version
-      - run: ./sauced show --human
+      - run: ./sauced show --pretty
+      - run: ./sauced show --id test-tunnel
+      - run: ./sauced show --pool test-pool

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sauced
+# Sauced
 [![CircleCI](https://circleci.com/gh/mdsauce/sauced/tree/master.svg?style=svg)](https://circleci.com/gh/mdsauce/sauced/tree/master)
 Managed Sauce Connect tunnels.
 
@@ -7,7 +7,7 @@ Managed Sauce Connect tunnels.
 ### Install and Run
 `go get github.com/mdsauce/sauced` or clone the repo and put it in `$GOPATH/github.com/mdsauce/sauced`.
 
-Create your [config](https://github.com/mdsauce/sauced#config-file) file like:
+Create your [config](https://github.com/mdsauce/sauced#config-file) file for sauce labs like below.  You must manually put the access key and username in, environment variables will not be read.
 
 ```
 # ~/.config/sauced-config.txt

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Managed Sauce Connect tunnels.
 Create your [config](https://github.com/mdsauce/sauced#config-file) file for sauce labs like below.  You must manually put the access key and username in, environment variables will not be read.
 
 ```
+# '#' <- This is a comment and the line will be ignored.
 # ~/.config/sauced-config.txt
 # main tunnel pool
 /Users/maxdobeck/workspace/sauce_connect/sc-4.5.1-osx/bin/sc -u sauce.username -k sauce.access.key -v --no-remove-colliding-tunnels -N -i main-tunnel-pool --se-port 0 --pidfile /tmp/sc_client-1.pid 
@@ -43,3 +44,6 @@ An example of a pool of tunnels:
 
 ### Testing
 Run `$ go test ./...`.
+
+### Building for another platform
+Run the `build.sh` script and find the binary for the OS of your choosing in the `builds/` directory. 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Managed Sauce Connect tunnels.
 [Why](why.md)
 
 ### Install and Run
-`go get github.com/mdsauce/sauced` or clone the repo and put it in `$GOPATH/github.com/mdsauce/sauced`.
+1. `go get github.com/mdsauce/sauced`
+2.  clone the repo and put it in `$GOPATH/github.com/mdsauce/sauced`
 
 Create your [config](https://github.com/mdsauce/sauced#config-file) file for sauce labs like below.  You must manually put the access key and username in, environment variables will not be read.
 

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -16,9 +16,7 @@ package cmd
 
 import (
 	"github.com/mdsauce/sauced/logger"
-	"github.com/mdsauce/sauced/manager"
 	"github.com/mdsauce/sauced/output"
-
 	"github.com/spf13/cobra"
 )
 
@@ -28,14 +26,17 @@ var showCmd = &cobra.Command{
 	Short: "List all last known tunnels.",
 	Long:  `The tunnel state list will be pruned and then all active tunnels will be shown.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		logger.Disklog.Debug("show called by the user.  Pruning then listing all tunnels.")
-		manager.PruneState()
-		output.ShowStateJSON()
+		human, err := cmd.Flags().GetBool("human")
+		if err != nil {
+			logger.Disklog.Warn("Problem retrieving human flag", err)
+		}
+		output.PrintState(human)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(showCmd)
+	showCmd.PersistentFlags().Bool("human", false, "output ")
 
 	// Here you will define your flags and configuration settings.
 

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -39,24 +39,24 @@ var showCmd = &cobra.Command{
 			logger.Disklog.Warn("Problem retrieving pretty flag", err)
 		}
 
-		logger.Disklog.Debug("show called by the user. Pruning then listing all tunnels.")
 		manager.PruneState()
 
 		pool, _ := cmd.Flags().GetString("pool")
 		id, _ := cmd.Flags().GetString("id")
-
-		logger.Disklog.Debug("Pool name searched: ", pool)
-		logger.Disklog.Debug("ID searched: ", id)
 
 		switch pretty {
 		case true:
 			output.PrettyPrint(id, pool)
 		case false:
 			if pool == "" && id != "" {
+				logger.Disklog.Debug("ID searched: ", id)
 				output.ShowTunnelJSON(id)
 			} else if pool == "" && id == "" {
 				output.ShowStateJSON()
-			} else {
+			} else if pool != "" && id != "" {
+				logger.Disklog.Warn("Cannot search for both Pool and Tunnel ID.  Use --id OR --pool.")
+			} else if pool != "" && id == "" {
+				logger.Disklog.Debug("Pool searched: ", pool)
 				output.ShowPool(pool)
 			}
 		}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -73,6 +73,7 @@ var startCmd = &cobra.Command{
 				go manager.Start(fscanner.Text(), &wg, meta[pool])
 			}
 		}
+		// TODO catch the ctrl-c here if it comes.
 		wg.Wait()
 	},
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -26,7 +26,7 @@ var stopCmd = &cobra.Command{
 	Short: "Stop all running tunnels and close this program.",
 	Long:  `Use the last known tunnel state to stop all tunnels.  This process will close after SIGINT or kill signal has been deliverd to all tunnels.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		//TODO: This should be it's function since it's called on all files.
+		//TODO: This should be it's own function since it's called on all files.
 		logfile, err := cmd.Flags().GetString("logfile")
 		if err != nil {
 			logger.Disklog.Warn("Problem retrieving logfile flag", err)
@@ -37,20 +37,21 @@ var stopCmd = &cobra.Command{
 		id, _ := cmd.Flags().GetString("id")
 		all, _ := cmd.Flags().GetBool("all")
 
-		logger.Disklog.Debugf("All flag: %t", all)
-		logger.Disklog.Debugf("Pool name searched: %s", pool)
-		logger.Disklog.Debugf("ID searched: %s", id)
-
 		if all { // stop all tunnel regardless of other flags
+			logger.Disklog.Debugf("All flag: %t", all)
 			logger.Disklog.Info("Stopping all tunnels.")
 			manager.StopAll()
 			logger.Disklog.Info("All tunnels sent the Kill, Interrupt, or SIGINT signal. Sauced closing.")
 		} else if pool == "" && id != "" { // id is the only one set
+			logger.Disklog.Debugf("ID searched: %s", id)
 			logger.Disklog.Infof("Stopping tunnel ID: %s", id)
 			manager.StopTunnelByID(id)
 			logger.Disklog.Infof("Tunnel stopped")
 
+		} else if pool != "" && id != "" { // stop unexepected behavior.  technically possible to kill a tunnel AND a pool but keep it safe for now till further testing has been completed
+			logger.Disklog.Warn("You specified both --id and --pool.  Please only specify one.")
 		} else if pool != "" { // delete pool. doesn't matter if id is set too
+			logger.Disklog.Debugf("Pool name searched: %s", pool)
 			logger.Disklog.Infof("Stopping tunnel pool: %s", pool)
 			manager.StopTunnelsByPool(pool)
 			logger.Disklog.Infof("Tunnel pool stopped")

--- a/manager/parser_test.go
+++ b/manager/parser_test.go
@@ -1,0 +1,30 @@
+package manager
+
+import (
+	"testing"
+)
+
+func TestEatLine(t *testing.T) {
+	if eatLine("#") != true {
+		t.Error("# should be a comment character and ignored.")
+		t.Fail()
+	}
+
+	if eatLine("# ") != true {
+		t.Fail()
+	}
+
+	if eatLine("# this is- = a 32! test") != true {
+		t.Fail()
+	}
+
+	if eatLine("Hello!") != false {
+		t.Error("This is NOT a comment and should be read by the program. Something is wrong if this failed.")
+		t.Fail()
+	}
+
+	if eatLine("Test that this is NOT # a comment") != false {
+		t.Error("Inline comments may be supported at a future date.  But that date is not today.")
+		t.Fail()
+	}
+}

--- a/manager/state.go
+++ b/manager/state.go
@@ -127,6 +127,7 @@ func RemoveTunnel(targetPID int) {
 // PruneState will access the state file and
 // remove any entries that are not found by the OS
 func PruneState() {
+	logger.Disklog.Debug("Pruning tunnels")
 	state := GetLastKnownState()
 	for i := 0; i < len(state.Tunnels); i++ {
 		tunnel := state.Tunnels[i]

--- a/manager/state.go
+++ b/manager/state.go
@@ -16,8 +16,7 @@ type LastKnownTunnels struct {
 	Tunnels []Tunnel `json:"tunnels"`
 }
 
-// Tunnel is a json representation
-// of an OS process after SC has launched
+// Tunnel is a logical representation of a Sauce Connect tunnel once it has started on an OS
 type Tunnel struct {
 	PID        int       `json:"pid"`
 	AssignedID string    `json:"assignedID"`
@@ -95,14 +94,16 @@ func AddTunnel(launchArgs string, path string, PID int, meta Metadata, tunnelLog
 	var state LastKnownTunnels
 	tun := Tunnel{PID, asgnID, path, launchArgs, time.Now().UTC(), tunnelLog, meta}
 
-	rawValue, err := ioutil.ReadFile("/tmp/sauced-state.json")
+	rawState, err := ioutil.ReadFile("/tmp/sauced-state.json")
 	if err != nil {
 		logger.Disklog.Warn("Could not read from statefile: ", err)
 	}
-	if rawValue == nil {
+
+	// TODO can this be condensed so that we do the Unmarshall if rawState != nil ?
+	if rawState == nil {
 		state.Tunnels = append(state.Tunnels, tun)
 	} else {
-		json.Unmarshal(rawValue, &state)
+		json.Unmarshal(rawState, &state)
 		state.Tunnels = append(state.Tunnels, tun)
 	}
 

--- a/manager/state.go
+++ b/manager/state.go
@@ -29,6 +29,14 @@ type Tunnel struct {
 	Metadata   Metadata  `json:"metadata"`
 }
 
+// Empty returns true if there are no tunnels, false if one ore more tunnels are present
+func (tState LastKnownTunnels) Empty() bool {
+	if len(tState.Tunnels) == 0 {
+		return true
+	}
+	return false
+}
+
 // add later
 // func (tun Tunnel) rotateLog() error {
 // 	return nil

--- a/manager/state.go
+++ b/manager/state.go
@@ -92,7 +92,7 @@ func AddTunnel(launchArgs string, path string, PID int, meta Metadata, tunnelLog
 	createIPCFile()
 
 	var state LastKnownTunnels
-	tun := Tunnel{PID, asgnID, path, launchArgs, time.Now().UTC(), tunnelLog, meta}
+	tun := Tunnel{PID, asgnID, path, launchArgs, time.Now().In(time.Local), tunnelLog, meta}
 
 	rawState, err := ioutil.ReadFile("/tmp/sauced-state.json")
 	if err != nil {

--- a/manager/state.go
+++ b/manager/state.go
@@ -11,8 +11,7 @@ import (
 	"github.com/mdsauce/sauced/logger"
 )
 
-// LastKnownTunnels will a json object with
-// all tunnels that were previously known to be alive
+// LastKnownTunnels is a slice of all tunnels found in the statefile
 type LastKnownTunnels struct {
 	Tunnels []Tunnel `json:"tunnels"`
 }

--- a/manager/tunnel_test.go
+++ b/manager/tunnel_test.go
@@ -23,13 +23,15 @@ func TestSCStarts(t *testing.T) {
 
 // TestSCFailsOnBadInput asserts that only an actual argument to SC can start a tunnel
 func TestSCFailsOnBadInput(t *testing.T) {
-	scBinary := "/some/fake/path"
+	badPath := "/some/fake/path"
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go Start(scBinary, &wg, Metadata{})
+	go Start(badPath, &wg, Metadata{})
+	PruneState()
 	tunnels := GetLastKnownState()
-	if len(tunnels.Tunnels) != 0 {
-		t.Fail()
+	if tunnels.Empty() == false {
+		t.Log(tunnels.Tunnels)
+		t.Error("Tunnels started even with scBinary path: ", badPath)
 	}
 	StopAll()
 }

--- a/output/pretty.go
+++ b/output/pretty.go
@@ -1,7 +1,7 @@
 package output
 
 import (
-	"fmt"
+	"log"
 
 	"github.com/mdsauce/sauced/logger"
 	"github.com/mdsauce/sauced/manager"
@@ -31,25 +31,28 @@ func showStatePretty(state manager.LastKnownTunnels) {
 		noTunnels()
 		return
 	}
+	for _, tunnel := range state.Tunnels {
+		printTunnel(tunnel)
+	}
 }
 
 func noTunnels() {
-	fmt.Printf("\nNo tunnels are running right now!\n\n")
-	fmt.Println("Tunnels:")
-	fmt.Println("--------")
-	fmt.Print("None\n\n")
+	log.Printf("\nNo tunnels are running right now!\n\n")
+	log.Println("Tunnels:")
+	log.Println("--------")
+	log.Print("None\n\n")
 }
 
 func printTunnel(t manager.Tunnel) {
-	fmt.Println("\nTunnel Found")
-	fmt.Println("------------")
-	fmt.Println("PID: ", t.PID)
-	fmt.Println("Assigned ID: ", t.AssignedID)
-	fmt.Println("Name: ", t.Metadata.Pool)
-	fmt.Println("Tunnel Log Location: ", t.Log)
+	log.Println("\nTunnel Found")
+	log.Println("------------")
+	log.Println("PID: ", t.PID)
+	log.Println("Assigned ID: ", t.AssignedID)
+	log.Println("Name: ", t.Metadata.Pool)
+	log.Println("Tunnel Log Location: ", t.Log)
 	//convert to local OS timezone and humanize
 	// t.LaunchTime
-	fmt.Println("Owner: ", t.Metadata.Owner)
-	fmt.Println("Pool Size: ", t.Metadata.Size)
-	fmt.Println()
+	log.Println("Owner: ", t.Metadata.Owner)
+	log.Println("Pool Size: ", t.Metadata.Size)
+	log.Println()
 }

--- a/output/pretty.go
+++ b/output/pretty.go
@@ -51,15 +51,14 @@ func noTunnels() {
 }
 
 func printTunnel(t manager.Tunnel) {
-	log.Println("\nTunnel Found")
+	log.Print("Tunnel Found")
 	log.Println("------------")
 	log.Println("PID: ", t.PID)
 	log.Println("Assigned ID: ", t.AssignedID)
-	log.Println("Name: ", t.Metadata.Pool)
+	log.Println("Pool Name: ", t.Metadata.Pool)
 	log.Println("Tunnel Log Location: ", t.Log)
 	//convert to local OS timezone and humanize
 	// t.LaunchTime
 	log.Println("Owner: ", t.Metadata.Owner)
-	log.Println("Pool Size: ", t.Metadata.Size)
-	log.Println()
+	log.Print("Pool Size: ", t.Metadata.Size, "\n\n")
 }

--- a/output/pretty.go
+++ b/output/pretty.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"log"
+	"time"
 
 	"github.com/mdsauce/sauced/logger"
 	"github.com/mdsauce/sauced/manager"
@@ -57,8 +58,15 @@ func printTunnel(t manager.Tunnel) {
 	log.Println("Assigned ID: ", t.AssignedID)
 	log.Println("Pool Name: ", t.Metadata.Pool)
 	log.Println("Tunnel Log Location: ", t.Log)
-	//convert to local OS timezone and humanize
-	// t.LaunchTime
+	if time.Local == nil {
+		// alternative hard coding to PST.  Use this if something breaks with t.local
+		cali, _ := time.LoadLocation("America/Los_Angeles")
+		local := t.LaunchTime.In(cali)
+		log.Println("Launch Time (PST zone 24-hr):", local.Format("15:04:05 Mon Jan 2 2006"))
+	} else {
+		local := t.LaunchTime.In(time.Local)
+		log.Println("Launch Time (local 24-hr):", local.Format("15:04:05 Mon Jan 2 2006"))
+	}
 	log.Println("Owner: ", t.Metadata.Owner)
 	log.Print("Pool Size: ", t.Metadata.Size, "\n\n")
 }

--- a/output/pretty.go
+++ b/output/pretty.go
@@ -6,30 +6,31 @@ import (
 	"github.com/mdsauce/sauced/manager"
 )
 
-// humanOutput takes the last known state for the tunnels and outputs it in a concise & readable way
-func prettyOutputTunnel(id string) {
-	state := manager.GetLastKnownState()
+func showTunnelPretty(ID string, state manager.LastKnownTunnels) {
 	if state.Empty() == true {
-		fmt.Println("0 tunnels found by Sauced!")
-	} else {
-		fmt.Println(state)
+		noTunnels()
+		return
+	}
+
+}
+
+func showPoolPretty(pool string, state manager.LastKnownTunnels) {
+	if state.Empty() == true {
+		noTunnels()
+		return
 	}
 }
 
-func prettyOutputPool(pool string) {
-	state := manager.GetLastKnownState()
+func showStatePretty(state manager.LastKnownTunnels) {
 	if state.Empty() == true {
-		fmt.Println("0 tunnels found by Sauced!")
-	} else {
-		fmt.Println(state)
+		noTunnels()
+		return
 	}
 }
 
-func prettyOutputState() {
-	state := manager.GetLastKnownState()
-	if state.Empty() == true {
-		fmt.Println("0 tunnels found by Sauced!")
-	} else {
-		fmt.Println(state)
-	}
+func noTunnels() {
+	fmt.Printf("\nNo tunnels are running right now!\n\n")
+	fmt.Println("Tunnels:")
+	fmt.Println("--------")
+	fmt.Print("None\n\n")
 }

--- a/output/pretty.go
+++ b/output/pretty.go
@@ -1,0 +1,13 @@
+package output
+
+import (
+	"fmt"
+
+	"github.com/mdsauce/sauced/manager"
+)
+
+// humanOutput takes the last known state for the tunnels and outputs it in a concise & readable way
+func humanOutput() {
+	state := manager.GetLastKnownState()
+	fmt.Println(state)
+}

--- a/output/pretty.go
+++ b/output/pretty.go
@@ -12,7 +12,7 @@ func showTunnelPretty(ID string, state manager.LastKnownTunnels) {
 		noTunnels()
 		return
 	}
-	tunnel, err := state.FindTunnelsByID(ID)
+	tunnel, err := state.FindTunnelByID(ID)
 	if err != nil {
 		logger.Disklog.Warn("Problem searching Statefile for tunnel", " , ", ID, err)
 	}

--- a/output/pretty.go
+++ b/output/pretty.go
@@ -3,6 +3,7 @@ package output
 import (
 	"fmt"
 
+	"github.com/mdsauce/sauced/logger"
 	"github.com/mdsauce/sauced/manager"
 )
 
@@ -11,7 +12,11 @@ func showTunnelPretty(ID string, state manager.LastKnownTunnels) {
 		noTunnels()
 		return
 	}
-
+	tunnel, err := state.FindTunnelsByID(ID)
+	if err != nil {
+		logger.Disklog.Warn("Problem searching Statefile for tunnel", " , ", ID, err)
+	}
+	printTunnel(tunnel)
 }
 
 func showPoolPretty(pool string, state manager.LastKnownTunnels) {
@@ -33,4 +38,18 @@ func noTunnels() {
 	fmt.Println("Tunnels:")
 	fmt.Println("--------")
 	fmt.Print("None\n\n")
+}
+
+func printTunnel(t manager.Tunnel) {
+	fmt.Println("\nTunnel Found")
+	fmt.Println("------------")
+	fmt.Println("PID: ", t.PID)
+	fmt.Println("Assigned ID: ", t.AssignedID)
+	fmt.Println("Name: ", t.Metadata.Pool)
+	fmt.Println("Tunnel Log Location: ", t.Log)
+	//convert to local OS timezone and humanize
+	// t.LaunchTime
+	fmt.Println("Owner: ", t.Metadata.Owner)
+	fmt.Println("Pool Size: ", t.Metadata.Size)
+	fmt.Println()
 }

--- a/output/pretty.go
+++ b/output/pretty.go
@@ -44,7 +44,7 @@ func showStatePretty(state manager.LastKnownTunnels) {
 }
 
 func noTunnels() {
-	log.Printf("\nNo tunnels are running right now!\n\n")
+	log.Print("No tunnels are running right now!\n\n")
 	log.Println("Tunnels:")
 	log.Println("--------")
 	log.Print("None\n\n")

--- a/output/pretty.go
+++ b/output/pretty.go
@@ -9,15 +9,27 @@ import (
 // humanOutput takes the last known state for the tunnels and outputs it in a concise & readable way
 func prettyOutputTunnel(id string) {
 	state := manager.GetLastKnownState()
-	fmt.Println(state)
+	if state.Empty() == true {
+		fmt.Println("0 tunnels found by Sauced!")
+	} else {
+		fmt.Println(state)
+	}
 }
 
 func prettyOutputPool(pool string) {
 	state := manager.GetLastKnownState()
-	fmt.Println(state)
+	if state.Empty() == true {
+		fmt.Println("0 tunnels found by Sauced!")
+	} else {
+		fmt.Println(state)
+	}
 }
 
 func prettyOutputState() {
 	state := manager.GetLastKnownState()
-	fmt.Println(state)
+	if state.Empty() == true {
+		fmt.Println("0 tunnels found by Sauced!")
+	} else {
+		fmt.Println(state)
+	}
 }

--- a/output/pretty.go
+++ b/output/pretty.go
@@ -7,7 +7,17 @@ import (
 )
 
 // humanOutput takes the last known state for the tunnels and outputs it in a concise & readable way
-func humanOutput() {
+func prettyOutputTunnel(id string) {
+	state := manager.GetLastKnownState()
+	fmt.Println(state)
+}
+
+func prettyOutputPool(pool string) {
+	state := manager.GetLastKnownState()
+	fmt.Println(state)
+}
+
+func prettyOutputState() {
 	state := manager.GetLastKnownState()
 	fmt.Println(state)
 }

--- a/output/pretty.go
+++ b/output/pretty.go
@@ -24,6 +24,13 @@ func showPoolPretty(pool string, state manager.LastKnownTunnels) {
 		noTunnels()
 		return
 	}
+	tunnels, err := state.FindTunnelsByPool(pool)
+	if err != nil {
+		logger.Disklog.Warn("Problem searching for tunnels for specific pool", " , ", pool, err)
+	}
+	for _, tunnel := range tunnels {
+		printTunnel(tunnel)
+	}
 }
 
 func showStatePretty(state manager.LastKnownTunnels) {

--- a/output/pretty_test.go
+++ b/output/pretty_test.go
@@ -9,17 +9,22 @@ import (
 
 //TestPrettyState tests the
 func TestPrettyStateFindsTunnel(t *testing.T) {
-	state := simpleState()
-	// target := "test123"
+	target := "test123"
+	state := soloState(target)
 	showStatePretty(state)
 }
 
-func simpleState() manager.LastKnownTunnels {
-	meta := manager.Metadata{Size: 1, Pool: "test123", Owner: "me.user"}
+func TestPrettyStatePrintsEmpty(t *testing.T) {
+	state := emptystate()
+	showStatePretty(state)
+}
+
+func soloState(target string) manager.LastKnownTunnels {
+	meta := manager.Metadata{Size: 1, Pool: target, Owner: "me.user"}
 
 	var tunnel1 manager.Tunnel
 	tunnel1.PID = 12345
-	tunnel1.AssignedID = "test123"
+	tunnel1.AssignedID = "ab1lk5b1glah9s"
 	tunnel1.SCBinary = "some/path/to/sc.exe"
 	tunnel1.Args = "-v -u me.user -k some-secret-key"
 	tunnel1.LaunchTime = time.Now().UTC()
@@ -29,5 +34,10 @@ func simpleState() manager.LastKnownTunnels {
 	var state manager.LastKnownTunnels
 	state.Tunnels = append(state.Tunnels, tunnel1)
 
+	return state
+}
+
+func emptystate() manager.LastKnownTunnels {
+	var state manager.LastKnownTunnels
 	return state
 }

--- a/output/pretty_test.go
+++ b/output/pretty_test.go
@@ -29,6 +29,42 @@ func TestPrettyStateFindsTunnel(t *testing.T) {
 
 }
 
+func TestPrettyByID(t *testing.T) {
+	target := "test123"
+	state := soloState(target)
+
+	var buf bytes.Buffer
+	//log in this case is the log used by the Testing package
+	log.SetOutput(&buf)
+
+	showTunnelPretty(target, state)
+
+	if strings.Contains(buf.String(), target) == false {
+		t.Log("Current tunnels state: ", state)
+		t.Log("Output from func under test: ", buf.String())
+		t.Fail()
+	}
+
+}
+
+func TestPrettyByPool(t *testing.T) {
+	target := "pool123"
+	state := multiState(target)
+
+	var buf bytes.Buffer
+	//log in this case is the log used by the Testing package
+	log.SetOutput(&buf)
+
+	showPoolPretty(target, state)
+
+	if strings.Contains(buf.String(), target) == false {
+		t.Log("Current tunnels state: ", state)
+		t.Log("Output from func under test: ", buf.String())
+		t.Fail()
+	}
+
+}
+
 //TestPrettyStatePrintsEmpty confirms that empty Tunnels[] can be identified as such
 func TestPrettyStatePrintsEmpty(t *testing.T) {
 	state := emptyState()
@@ -59,6 +95,44 @@ func soloState(target string) manager.LastKnownTunnels {
 
 	var state manager.LastKnownTunnels
 	state.Tunnels = append(state.Tunnels, tunnel1)
+
+	return state
+}
+
+func multiState(target string) manager.LastKnownTunnels {
+	meta := manager.Metadata{Size: 3, Pool: target, Owner: "pool.admin"}
+
+	var tunnel1 manager.Tunnel
+	tunnel1.PID = 12345
+	tunnel1.AssignedID = "ab1lk5b1glah9s"
+	tunnel1.SCBinary = "some/path/to/sc.exe"
+	tunnel1.Args = "-v -u me.user -k some-secret-key"
+	tunnel1.LaunchTime = time.Now().UTC()
+	tunnel1.Log = "path/to/tunnels/log.log"
+	tunnel1.Metadata = meta
+
+	var tunnel2 manager.Tunnel
+	tunnel1.PID = 12346
+	tunnel1.AssignedID = "adn195b1g9ab"
+	tunnel1.SCBinary = "some/path/to/sc.exe"
+	tunnel1.Args = "-v -u me.user -k some-secret-key"
+	tunnel1.LaunchTime = time.Now().UTC()
+	tunnel1.Log = "path/to/tunnels/log2.log"
+	tunnel1.Metadata = meta
+
+	var tunnel3 manager.Tunnel
+	tunnel1.PID = 12347
+	tunnel1.AssignedID = "19bgalb159blas91"
+	tunnel1.SCBinary = "some/path/to/sc.exe"
+	tunnel1.Args = "-v -u me.user -k some-secret-key"
+	tunnel1.LaunchTime = time.Now().UTC()
+	tunnel1.Log = "path/to/tunnels/log.log"
+	tunnel1.Metadata = meta
+
+	var state manager.LastKnownTunnels
+	state.Tunnels = append(state.Tunnels, tunnel1)
+	state.Tunnels = append(state.Tunnels, tunnel2)
+	state.Tunnels = append(state.Tunnels, tunnel3)
 
 	return state
 }

--- a/output/pretty_test.go
+++ b/output/pretty_test.go
@@ -7,13 +7,14 @@ import (
 	"github.com/mdsauce/sauced/manager"
 )
 
-//TestPrettyState tests the
+//TestPrettyStateFindsTunnel confirms that the target tunnel can be located
 func TestPrettyStateFindsTunnel(t *testing.T) {
 	target := "test123"
 	state := soloState(target)
 	showStatePretty(state)
 }
 
+//TestPrettyStatePrintsEmpty confirms that empty Tunnels[] can be identified as such
 func TestPrettyStatePrintsEmpty(t *testing.T) {
 	state := emptystate()
 	showStatePretty(state)

--- a/output/pretty_test.go
+++ b/output/pretty_test.go
@@ -1,6 +1,9 @@
 package output
 
 import (
+	"bytes"
+	"log"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,12 +14,24 @@ import (
 func TestPrettyStateFindsTunnel(t *testing.T) {
 	target := "test123"
 	state := soloState(target)
+
+	var buf bytes.Buffer
+	//log in this case is the log used by the Testing package
+	log.SetOutput(&buf)
+
 	showStatePretty(state)
+
+	if strings.Contains(buf.String(), target) == false {
+		t.Log(state)
+		t.Log(buf.String())
+		t.Fail()
+	}
+
 }
 
 //TestPrettyStatePrintsEmpty confirms that empty Tunnels[] can be identified as such
 func TestPrettyStatePrintsEmpty(t *testing.T) {
-	state := emptystate()
+	state := emptyState()
 	showStatePretty(state)
 }
 
@@ -38,7 +53,7 @@ func soloState(target string) manager.LastKnownTunnels {
 	return state
 }
 
-func emptystate() manager.LastKnownTunnels {
+func emptyState() manager.LastKnownTunnels {
 	var state manager.LastKnownTunnels
 	return state
 }

--- a/output/pretty_test.go
+++ b/output/pretty_test.go
@@ -1,0 +1,33 @@
+package output
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mdsauce/sauced/manager"
+)
+
+//TestPrettyState tests the
+func TestPrettyStateFindsTunnel(t *testing.T) {
+	state := simpleState()
+	// target := "test123"
+	showStatePretty(state)
+}
+
+func simpleState() manager.LastKnownTunnels {
+	meta := manager.Metadata{Size: 1, Pool: "test123", Owner: "me.user"}
+
+	var tunnel1 manager.Tunnel
+	tunnel1.PID = 12345
+	tunnel1.AssignedID = "test123"
+	tunnel1.SCBinary = "some/path/to/sc.exe"
+	tunnel1.Args = "-v -u me.user -k some-secret-key"
+	tunnel1.LaunchTime = time.Now().UTC()
+	tunnel1.Log = "path/to/tunnels/log.log"
+	tunnel1.Metadata = meta
+
+	var state manager.LastKnownTunnels
+	state.Tunnels = append(state.Tunnels, tunnel1)
+
+	return state
+}

--- a/output/pretty_test.go
+++ b/output/pretty_test.go
@@ -22,8 +22,8 @@ func TestPrettyStateFindsTunnel(t *testing.T) {
 	showStatePretty(state)
 
 	if strings.Contains(buf.String(), target) == false {
-		t.Log(state)
-		t.Log(buf.String())
+		t.Log("Current tunnels state: ", state)
+		t.Log("Output from func under test: ", buf.String())
 		t.Fail()
 	}
 
@@ -32,7 +32,17 @@ func TestPrettyStateFindsTunnel(t *testing.T) {
 //TestPrettyStatePrintsEmpty confirms that empty Tunnels[] can be identified as such
 func TestPrettyStatePrintsEmpty(t *testing.T) {
 	state := emptyState()
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+
 	showStatePretty(state)
+
+	if strings.Contains(buf.String(), "No tunnels are running right now!") == false {
+		t.Log("Current tunnels state: ", state)
+		t.Log("Output from func under test: ", buf.String())
+		t.Fail()
+	}
 }
 
 func soloState(target string) manager.LastKnownTunnels {

--- a/output/simpleui.go
+++ b/output/simpleui.go
@@ -7,8 +7,21 @@ import (
 	"github.com/mdsauce/sauced/manager"
 )
 
-// ShowStateJSON will pretty print JSON
-func ShowStateJSON() {
+// PrintState is called by a user to output some sort of detailed info on the active tunnels
+func PrintState(human bool) {
+	if !human {
+		// print the default
+		logger.Disklog.Debug("show called by the user.  Pruning then listing all tunnels.")
+		manager.PruneState()
+		showStateJSON()
+	}
+	if human {
+		humanOutput()
+	}
+}
+
+// showStateJSON will pretty print JSON
+func showStateJSON() {
 	last := manager.GetLastKnownState()
 	lastJSON, err := json.MarshalIndent(last, "", "    ")
 	if err != nil {

--- a/output/simpleui.go
+++ b/output/simpleui.go
@@ -9,12 +9,13 @@ import (
 
 // PrettyPrint is called by a user to output some sort of detailed info on the active tunnels
 func PrettyPrint(id string, pool string) {
+	state := manager.GetLastKnownState()
 	if id != "" {
-		prettyOutputTunnel(id)
+		showTunnelPretty(id, state)
 	} else if pool != "" {
-		prettyOutputPool(pool)
+		showPoolPretty(pool)
 	} else {
-		prettyOutputState()
+		showStatePretty()
 	}
 }
 
@@ -35,7 +36,7 @@ func ShowTunnelJSON(assignedID string) {
 	tunnels, err := tstate.FindTunnelsByID(assignedID)
 
 	if err != nil {
-		logger.Disklog.Info(err)
+		logger.Disklog.Warn(err, ", Tunnel Assigned ID: ", assignedID)
 	} else {
 		tunnelsJSON, err := json.MarshalIndent(tunnels, "", "    ")
 		if err != nil {
@@ -52,7 +53,7 @@ func ShowPool(poolName string) {
 	tunnels, err := tstate.FindTunnelsByPool(poolName)
 
 	if err != nil {
-		logger.Disklog.Info(err)
+		logger.Disklog.Warn(err, ", Pool Name: ", poolName)
 	} else {
 		tunnelsJSON, err := json.MarshalIndent(tunnels, "", "    ")
 		if err != nil {

--- a/output/simpleui.go
+++ b/output/simpleui.go
@@ -13,9 +13,9 @@ func PrettyPrint(id string, pool string) {
 	if id != "" {
 		showTunnelPretty(id, state)
 	} else if pool != "" {
-		showPoolPretty(pool)
+		showPoolPretty(pool, state)
 	} else {
-		showStatePretty()
+		showStatePretty(state)
 	}
 }
 

--- a/output/simpleui.go
+++ b/output/simpleui.go
@@ -7,21 +7,19 @@ import (
 	"github.com/mdsauce/sauced/manager"
 )
 
-// PrintState is called by a user to output some sort of detailed info on the active tunnels
-func PrintState(human bool) {
-	if !human {
-		// print the default
-		logger.Disklog.Debug("show called by the user.  Pruning then listing all tunnels.")
-		manager.PruneState()
-		showStateJSON()
-	}
-	if human {
-		humanOutput()
+// PrettyPrint is called by a user to output some sort of detailed info on the active tunnels
+func PrettyPrint(id string, pool string) {
+	if id != "" {
+		prettyOutputTunnel(id)
+	} else if pool != "" {
+		prettyOutputPool(pool)
+	} else {
+		prettyOutputState()
 	}
 }
 
-// showStateJSON will pretty print JSON
-func showStateJSON() {
+// ShowStateJSON will pretty print JSON
+func ShowStateJSON() {
 	last := manager.GetLastKnownState()
 	lastJSON, err := json.MarshalIndent(last, "", "    ")
 	if err != nil {


### PR DESCRIPTION
There's a lot in here:
- refactor of show.go 
- slight refactor of stop.go to condense logging messages
- new pattern in show.go when it comes to adding in the `--pretty` flag and interoperability with `--id` and `--pool`
- new pattern for output in pretty.go which lends itself to testing but increases outside dependencies by passing the LastKnownState as a parameter
- new kinds of stubbing/psuedo state for testing in pretty_test.go.  example of capturing STD library log output in the test