### PR TITLE
Metadata refactor

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -69,9 +69,7 @@ var startCmd = &cobra.Command{
 		for fscanner.Scan() {
 			if fscanner.Text() != "" || len(fscanner.Text()) != 0 {
 				wg.Add(1)
-				metadata := make(chan string)
-				go manager.PoolName(fscanner.Text(), metadata)
-				pool := <-metadata
+				pool := manager.PoolName(fscanner.Text())
 				logger.Disklog.Debugf("%s pool is %s.  Metadata is %v", fscanner.Text(), pool, meta[pool])
 				go manager.Start(fscanner.Text(), &wg, meta[pool])
 			}

--- a/manager/tunnel_unix.go
+++ b/manager/tunnel_unix.go
@@ -4,10 +4,12 @@ package manager
 
 import (
 	"bufio"
+	"math/rand"
 	"os"
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/mdsauce/sauced/logger"
 )
@@ -29,6 +31,8 @@ func Start(launchArgs string, wg *sync.WaitGroup, meta Metadata) {
 	manufacturedArgs := setDefaults(args)
 	logger.Disklog.Debug("Created new set of args with sensible defaults that will be passed to exec.Command: ", manufacturedArgs)
 	// tunnel is actually launched here.  new process is spawned
+	wait := rand.Intn(10)
+	time.Sleep(time.Duration(wait) * time.Second)
 	scCmd := exec.Command(path, manufacturedArgs[1:]...)
 	stdout, _ := scCmd.StdoutPipe()
 	err := scCmd.Start()
@@ -37,7 +41,7 @@ func Start(launchArgs string, wg *sync.WaitGroup, meta Metadata) {
 		return
 	}
 
-	logger.Disklog.Infof("Tunnel started as process %d - %s\n", scCmd.Process.Pid, launchArgs)
+	logger.Disklog.Infof("Tunnel started as process %d - %s.  Raw launch arguments: %s\n", scCmd.Process.Pid, manufacturedArgs, launchArgs)
 	scanner := bufio.NewScanner(stdout)
 	scanner.Split(bufio.ScanLines)
 

--- a/manager/tunnel_unix.go
+++ b/manager/tunnel_unix.go
@@ -67,7 +67,7 @@ func Start(launchArgs string, wg *sync.WaitGroup, meta Metadata) {
 			AddTunnel(launchArgs, path, scCmd.Process.Pid, meta, tunLog, asgnID)
 		}
 	}
-	logger.Disklog.Infof("Sauce Connect client with PID %d shutting down!  Goodbye!", scCmd.Process.Pid)
+	logger.Disklog.Infof("Sauce Connect client with PID %d shutting down!  If you want more details check our logfile %s  Goodbye!", scCmd.Process.Pid, tunLog)
 	RemoveTunnel(scCmd.Process.Pid)
 	defer scCmd.Wait()
 }

--- a/manager/tunnel_unix.go
+++ b/manager/tunnel_unix.go
@@ -28,7 +28,6 @@ func Start(launchArgs string, wg *sync.WaitGroup, meta Metadata) {
 		return
 	}
 
-	// setDefaults() should go here.  take launchArgs and add all necessary default args/flags.
 	manufacturedArgs := setDefaults(args)
 	meta.Owner = GetOwner(strings.Join(manufacturedArgs, " "))
 	logger.Disklog.Debug("Created new set of args with sensible defaults that will be passed to exec.Command: ", manufacturedArgs)

--- a/manager/tunnel_unix.go
+++ b/manager/tunnel_unix.go
@@ -27,11 +27,14 @@ func Start(launchArgs string, wg *sync.WaitGroup, meta Metadata) {
 		logger.Disklog.Warnf("Too many tunnels open.  Not opening %s \n %v", meta.Pool, launchArgs)
 		return
 	}
+
 	// setDefaults() should go here.  take launchArgs and add all necessary default args/flags.
 	manufacturedArgs := setDefaults(args)
+	meta.Owner = GetOwner(strings.Join(manufacturedArgs, " "))
 	logger.Disklog.Debug("Created new set of args with sensible defaults that will be passed to exec.Command: ", manufacturedArgs)
 	// tunnel is actually launched here.  new process is spawned
-	wait := rand.Intn(10)
+	rand.Seed(time.Now().UnixNano())
+	wait := rand.Intn(15)
 	time.Sleep(time.Duration(wait) * time.Second)
 	scCmd := exec.Command(path, manufacturedArgs[1:]...)
 	stdout, _ := scCmd.StdoutPipe()


### PR DESCRIPTION
Refactor how metadata is gathered.  Remove channels from cmd/start.go when collecting metadata like pool name and owner of tunnel.
Fixes #71 

Also added some basic refactor/output cleanup.