### PR TITLE
Qol refactor

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/mdsauce/sauced/logger"
 	"github.com/spf13/cobra"
 )
 
@@ -32,6 +33,14 @@ Each tunnel should be on one line and separated by a newline character.  Use the
 to start all the specified tunnels.  Stop cmd will stop all tunnels that were started by the
 program.`,
 	Version: fmt.Sprintf("%s", CurVersion),
+	// Persistent*Run hooks are inherited by all subcommands if they do not have hooks themselves
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		logfile, err := cmd.Flags().GetString("logfile")
+		if err != nil {
+			logger.Disklog.Warn("Problem retrieving logfile flag", err)
+		}
+		logger.SetupLogfile(logfile)
+	},
 	// Run: func(cmd *cobra.Command, args []string) {
 	// },
 }
@@ -47,11 +56,12 @@ func Execute() {
 
 func init() {
 	rootCmd.Flags().Bool("version", false, "Print the version of sauced")
+	rootCmd.Flags().Bool("verbose", false, "Print out all sauced logging information")
+	rootCmd.PersistentFlags().StringP("logfile", "l", "/tmp/sauced.log", "logfile for meta-status output")
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.config/sauced.yaml)")
-	rootCmd.PersistentFlags().StringP("logfile", "l", "/tmp/sauced.log", "logfile for meta-status output")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,9 +37,13 @@ program.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		logfile, err := cmd.Flags().GetString("logfile")
 		if err != nil {
-			logger.Disklog.Warn("Problem retrieving logfile flag", err)
+			logger.Disklog.Warn("Problem retrieving logfile flag: ", err)
 		}
-		logger.SetupLogfile(logfile)
+		verbose, err := cmd.Flags().GetBool("verbose")
+		if err != nil {
+			logger.Disklog.Warn("Problem retrieving verbosity flag: ", err)
+		}
+		logger.SetupLogfile(logfile, verbose)
 	},
 	// Run: func(cmd *cobra.Command, args []string) {
 	// },
@@ -56,7 +60,7 @@ func Execute() {
 
 func init() {
 	rootCmd.Flags().Bool("version", false, "Print the version of sauced")
-	rootCmd.Flags().Bool("verbose", false, "Print out all sauced logging information")
+	rootCmd.PersistentFlags().Bool("verbose", false, "Print out all sauced logging information")
 	rootCmd.PersistentFlags().StringP("logfile", "l", "/tmp/sauced.log", "logfile for meta-status output")
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -27,13 +27,6 @@ var showCmd = &cobra.Command{
 	Short: "List all last known tunnels.",
 	Long:  `The tunnel state list will be pruned and then all active tunnels will be shown.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		//TODO: This should be it's function since it's called on all files.
-		logfile, err := cmd.Flags().GetString("logfile")
-		if err != nil {
-			logger.Disklog.Warn("Problem retrieving logfile flag", err)
-		}
-		logger.SetupLogfile(logfile)
-
 		pretty, err := cmd.Flags().GetBool("pretty")
 		if err != nil {
 			logger.Disklog.Warn("Problem retrieving pretty flag", err)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -35,13 +35,6 @@ var startCmd = &cobra.Command{
 	Short: "Start all tunnels listed in your config file you reference.",
 	Long:  `Start all tunnels in the config file you reference like $ sauced start ~/my-config.txt`,
 	Run: func(cmd *cobra.Command, args []string) {
-
-		logfile, err := cmd.Flags().GetString("logfile")
-		if err != nil {
-			logger.Disklog.Warn("Problem retrieving logfile flag", err)
-		}
-		logger.SetupLogfile(logfile)
-
 		configFile, err := cmd.Flags().GetString("config")
 		if err != nil {
 			logger.Disklog.Warn("Problem retrieving config file flag", err)

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -26,13 +26,6 @@ var stopCmd = &cobra.Command{
 	Short: "Stop all running tunnels and close this program.",
 	Long:  `Use the last known tunnel state to stop all tunnels.  This process will close after SIGINT or kill signal has been deliverd to all tunnels.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		//TODO: This should be it's own function since it's called on all files.
-		logfile, err := cmd.Flags().GetString("logfile")
-		if err != nil {
-			logger.Disklog.Warn("Problem retrieving logfile flag", err)
-		}
-		logger.SetupLogfile(logfile)
-
 		pool, _ := cmd.Flags().GetString("pool")
 		id, _ := cmd.Flags().GetString("id")
 		all, _ := cmd.Flags().GetBool("all")

--- a/logger/globalInit.go
+++ b/logger/globalInit.go
@@ -13,21 +13,27 @@ var Disklog = log.New()
 
 // SetupLogfile will take in the user spec'd flag
 // and attempt to create a logfile if one does not exist
-func SetupLogfile(logfile string) {
+func SetupLogfile(logfile string, verbose bool) {
 	Disklog.SetFormatter(&log.TextFormatter{})
-	Disklog.SetLevel(log.DebugLevel)
+	if verbose {
+		Disklog.SetLevel(log.DebugLevel)
+	} else {
+		Disklog.SetLevel(log.InfoLevel)
+	}
+
 	Disklog.Out = os.Stdout
+	// May be a logrus bug but the first log output has to be Info or it doesn't format in a pretty way  :shrug:
 	Disklog.Info("Looking for logfile: ", logfile)
 	if _, err := os.Stat(logfile); err == nil {
-		Disklog.Info("Using existing file: ", logfile)
+		Disklog.Debug("Using existing file: ", logfile)
 		file, err := os.OpenFile(logfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 		multi := io.MultiWriter(os.Stdout, file)
 
 		if err != nil {
-			log.Info("Failed to log to file, using default stdout")
+			log.Warn("Failed to log to file, using default stdout")
 		} else {
 			Disklog.Out = multi
-			Disklog.Info("Started program and now writing to ", logfile)
+			Disklog.Debug("Started program and now writing to ", logfile)
 		}
 	} else if os.IsNotExist(err) {
 		log.Debug(logfile, " NOT found: ", err)
@@ -35,10 +41,10 @@ func SetupLogfile(logfile string) {
 		multi := io.MultiWriter(os.Stdout, file)
 
 		if err != nil {
-			log.Info("Failed to log to file, using default stderr")
+			log.Warn("Failed to log to file, using default stderr")
 		} else {
 			Disklog.Out = multi
-			Disklog.Infof("Started program and now writing to %s.", logfile)
+			Disklog.Debugf("Started program and now writing to %s.", logfile)
 		}
 	} else {
 		log.Warn("unable to set the logfile to", logfile)

--- a/manager/balancer.go
+++ b/manager/balancer.go
@@ -5,7 +5,7 @@ import (
 )
 
 func balance(lastState []Tunnel, pool string) int {
-	logger.Disklog.Infof("Counting active tunnels from Last Known State: %v", lastState)
+	logger.Disklog.Debugf("Counting active tunnels from Last Known State: %v", lastState)
 	count := 0
 	for _, tunnel := range lastState {
 		if tunnel.Metadata.Pool == pool {

--- a/manager/metadata.go
+++ b/manager/metadata.go
@@ -19,7 +19,7 @@ type Metadata struct {
 // CollectMetadata parses the config file for important
 // data points and returns the formatted metadata
 func CollectMetadata(config string) map[string]Metadata {
-	logger.Disklog.Infof("Started collecting metadata from %s", config)
+	logger.Disklog.Debugf("Started collecting metadata from %s", config)
 	meta := make(map[string]Metadata)
 	file, _ := os.Open(config)
 	fscanner := bufio.NewScanner(file)

--- a/manager/tunnel_unix.go
+++ b/manager/tunnel_unix.go
@@ -57,13 +57,13 @@ func Start(launchArgs string, wg *sync.WaitGroup, meta Metadata) {
 		if strings.Contains(m, "Log file:") {
 			ll := strings.Split(m, " ")
 			tunLog = ll[len(ll)-1]
-			logger.Disklog.Infof("Tunnel log started for tunnel: %s \n %s", launchArgs, m)
+			logger.Disklog.Debugf("Tunnel log started for tunnel: %s \n %s", launchArgs, m)
 		}
 		// should be a func that is unit tested
 		if strings.Contains(m, "Tunnel ID:") {
 			idLine := strings.Split(m, " ")
 			asgnID = idLine[len(idLine)-1]
-			logger.Disklog.Infof("Tunnel: %s has AssignedID %s", launchArgs, asgnID)
+			logger.Disklog.Infof("TUNNEL IS ALIVE as process %d with Assigned ID %s. args: %s", scCmd.Process.Pid, asgnID, manufacturedArgs)
 		}
 		if strings.Contains(m, "Sauce Connect is up") {
 			AddTunnel(launchArgs, path, scCmd.Process.Pid, meta, tunLog, asgnID)
@@ -93,7 +93,7 @@ func StopTunnelByID(assignedID string) {
 	tunnel, err := tstate.FindTunnelByID(assignedID)
 
 	if err != nil {
-		logger.Disklog.Info(err)
+		logger.Disklog.Warn(err)
 	} else {
 		Stop(tunnel.PID)
 	}
@@ -106,7 +106,7 @@ func StopTunnelsByPool(poolName string) {
 	tunnels, err := tstate.FindTunnelsByPool(poolName)
 
 	if err != nil {
-		logger.Disklog.Info(err)
+		logger.Disklog.Warn(err)
 	} else {
 		for _, tunnel := range tunnels {
 			Stop(tunnel.PID)


### PR DESCRIPTION
WOOOOOah this is dope.  turns out there was an easy solution for log initialization all along.  Hooks!
from readme on cobra under Hooks
>...The Persistent*Run functions will be inherited by children if they do not declare their own. 

So I just added it to the root command.  I also added a --verbose flag to sauced and cleaned up some of what is set as "info".  So there's less output and stuff the end user would care about.