### PR TITLE
Tunnel struct

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -138,6 +138,15 @@ func launch(config string) {
 		logger.Disklog.Error("YAML is not supported at this time.  Cannot use config file: ", configFile)
 	} else if strings.Contains(viper.ConfigFileUsed(), ".toml") || strings.Contains(config, ".toml") {
 		logger.Disklog.Info("Found TOML config file: ", viper.ConfigFileUsed())
+		var configs []manager.TunnelConfig
+		if err := viper.ReadInConfig(); err != nil {
+			logger.Disklog.Fatalf("Error reading config file, %s", err)
+		}
+		err := viper.Unmarshal(&configs)
+		if err != nil {
+			logger.Disklog.Fatalf("Unable to unmarsahll config file %s into TunnelConfig struct(s): %v", viper.ConfigFileUsed(), err)
+		}
+		fmt.Println(configs)
 	} else if viper.ConfigFileUsed() == "" && configFile == "" {
 		unstructuredConfig(findXdgConfigHome())
 	} else {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -138,7 +138,7 @@ func launch(config string) {
 		logger.Disklog.Error("YAML is not supported at this time.  Cannot use config file: ", configFile)
 	} else if strings.Contains(viper.ConfigFileUsed(), ".toml") || strings.Contains(config, ".toml") {
 		logger.Disklog.Info("Found TOML config file: ", viper.ConfigFileUsed())
-		var configs []manager.TunnelConfig
+		configs := make(map[string]manager.TunnelConfig)
 		if err := viper.ReadInConfig(); err != nil {
 			logger.Disklog.Fatalf("Error reading config file, %s", err)
 		}
@@ -146,7 +146,9 @@ func launch(config string) {
 		if err != nil {
 			logger.Disklog.Fatalf("Unable to unmarsahll config file %s into TunnelConfig struct(s): %v", viper.ConfigFileUsed(), err)
 		}
+		fmt.Println(viper.Get("tunnel"))
 		fmt.Println(configs)
+		fmt.Println("Pool Size is: ", configs["tunnel"].PoolSize)
 	} else if viper.ConfigFileUsed() == "" && configFile == "" {
 		unstructuredConfig(findXdgConfigHome())
 	} else {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -57,7 +57,7 @@ func initConfig() {
 	} else {
 		home, err := homedir.Dir()
 		if err != nil {
-			fmt.Println(err)
+			logger.Disklog.Warn(err)
 			os.Exit(1)
 		}
 
@@ -163,8 +163,8 @@ func mapToSlice(config map[string]manager.TunnelArgs) []manager.TunnelArgs {
 		c[i].TunnelIdentifier = k
 		i++
 	}
-	fmt.Println(c, config)
-	fmt.Println("Pool Size is: ", c[0].PoolSize)
+	logger.Disklog.Debugf("Converted map %v to slice %v", c, config)
+	logger.Disklog.Debug("Pool Size is: ", c[0].PoolSize)
 	return c
 }
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -138,22 +138,34 @@ func launch(config string) {
 		logger.Disklog.Error("YAML is not supported at this time.  Cannot use config file: ", configFile)
 	} else if strings.Contains(viper.ConfigFileUsed(), ".toml") || strings.Contains(config, ".toml") {
 		logger.Disklog.Info("Found TOML config file: ", viper.ConfigFileUsed())
-		configs := make(map[string]manager.TunnelConfig)
+		configMap := make(map[string]manager.TunnelArgs)
 		if err := viper.ReadInConfig(); err != nil {
 			logger.Disklog.Fatalf("Error reading config file, %s", err)
 		}
-		err := viper.Unmarshal(&configs)
+		err := viper.Unmarshal(&configMap)
 		if err != nil {
-			logger.Disklog.Fatalf("Unable to unmarsahll config file %s into TunnelConfig struct(s): %v", viper.ConfigFileUsed(), err)
+			logger.Disklog.Fatalf("Unable to unmarshal config file %s: %v", viper.ConfigFileUsed(), err)
 		}
-		fmt.Println(viper.Get("tunnel"))
+		configs := mapToSlice(configMap)
 		fmt.Println(configs)
-		fmt.Println("Pool Size is: ", configs["tunnel"].PoolSize)
 	} else if viper.ConfigFileUsed() == "" && configFile == "" {
 		unstructuredConfig(findXdgConfigHome())
 	} else {
 		unstructuredConfig(configFile)
 	}
+}
+
+func mapToSlice(config map[string]manager.TunnelArgs) []manager.TunnelArgs {
+	c := []manager.TunnelArgs{}
+	i := 0
+	for k, v := range config {
+		c = append(c, v)
+		c[i].TunnelIdentifier = k
+		i++
+	}
+	fmt.Println(c, config)
+	fmt.Println("Pool Size is: ", c[0].PoolSize)
+	return c
 }
 
 func unstructuredConfig(configFile string) {

--- a/examples/minimal-sauced.toml
+++ b/examples/minimal-sauced.toml
@@ -1,6 +1,4 @@
-[my-main-pool]
+[tunnel-pool-1]
+tunnel-identifier = "simple-tunnel"
 pool-size = 3
-very-verbose: false
-
-[no-bump-tunnel]
-no-bump = "all"
+very-verbose = false

--- a/examples/minimal-sauced.toml
+++ b/examples/minimal-sauced.toml
@@ -1,4 +1,4 @@
-[tunnel-pool-1]
+[tunnel]
 tunnel-identifier = "simple-tunnel"
 pool-size = 3
 very-verbose = false

--- a/examples/minimal-sauced.toml
+++ b/examples/minimal-sauced.toml
@@ -1,3 +1,6 @@
 [simple-tunnel]    
 pool-size = 3
 very-verbose = false
+
+[verbose-troubleshooting]
+very-verbose = true

--- a/examples/minimal-sauced.toml
+++ b/examples/minimal-sauced.toml
@@ -1,4 +1,3 @@
-[tunnel]
-tunnel-identifier = "simple-tunnel"
+[simple-tunnel]    
 pool-size = 3
 very-verbose = false

--- a/examples/minimal-sauced.yaml
+++ b/examples/minimal-sauced.yaml
@@ -1,0 +1,6 @@
+- simple-tunnel:
+    pool-size = 3
+    very-verbose = false
+
+- verbose-troubleshooting:
+    very-verbose = true

--- a/manager/tunnel.go
+++ b/manager/tunnel.go
@@ -1,7 +1,7 @@
 package manager
 
-// TunnelConfig represents all the configs collected from a user's config file
-type TunnelConfig struct {
+// TunnelArgs represents all the configs collected from a user's config file
+type TunnelArgs struct {
 	Owner                  string   `json:"owner" mapstructure:"owner"`
 	APIKey                 string   `json:"api_key" mapstructure:"api-key"`
 	Cainfo                 string   `json:"cainfo" mapstructure:"cainfo"`

--- a/manager/tunnel.go
+++ b/manager/tunnel.go
@@ -1,4 +1,43 @@
 package manager
 
-type tunnel struct {
+// TunnelConfig represents all the configs collected from a user's config file
+type TunnelConfig struct {
+	Owner                  string   `json:"owner" mapstructure:"owner"`
+	APIKey                 string   `json:"api_key" mapstructure:"api-key"`
+	Cainfo                 string   `json:"cainfo" mapstructure:"cainfo"`
+	Capath                 string   `json:"capath" mapstructure:"capath"`
+	Certfile               string   `json:"certfile" mapstructure:"certificate"`
+	DNS                    []string `json:"dns" mapstructure:"dns"`
+	DirectDomains          []string `json:"direct_domains" mapstructure:"direct-domains"`
+	FastFailRegexps        []string `json:"fast_fail_regexps" mapstructure:"fast-fail-regexps"`
+	Logfile                string   `json:"logfile" mapstructure:"logfile"`
+	MaxLogsize             int64    `json:"max_logsize" mapstructure:"max-logsize"`
+	MetricsAddress         string   `json:"metrics_address" mapstructure:"metrics-address"`
+	NoAutodetect           bool     `json:"no_autodetect" mapstructure:"no-autodetect"`
+	NoCertVerifyFlag       bool     `json:"no_cert_verify" mapstructure:"no-cert-verify"`
+	NoHTTPCertVerifyFlag   bool     `json:"no_http_cert_verify" mapstructure:"no-http-cert-verify"`
+	NoProxyCachingFlag     bool     `json:"no_proxy_caching_flag" mapstructure:"no-proxy-caching"`
+	NoSslBumpDomains       []string `json:"no_ssl_bump_domains" mapstructure:"no-ssl-bump-domains"`
+	OutputConfigFlag       bool     `json:"output_config_flag" mapstructure:"output-config"`
+	Pacurl                 string   `json:"pacurl" mapstructure:"pac"`
+	Pidfile                string   `json:"pidfile" mapstructure:"pidfile"`
+	Proxy                  string   `json:"proxy" mapstructure:"proxy"`
+	ProxyTunnelFlag        bool     `json:"proxy_tunnel_flag" mapstructure:"proxy-tunnel"`
+	ProxyUserpwd           string   `json:"proxy_userpwd" mapstructure:"proxy-userpwd"`
+	Readyfile              string   `json:"readyfile" mapstructure:"readyfile"`
+	RemoveCollidingTunnels bool     `json:"remove_colliding_tunnels"`
+	RestURL                string   `json:"rest_url" mapstructure:"rest-url"`
+	ScproxyPort            int      `json:"scproxy_port" mapstructure:"scproxy-port"`
+	ScproxyReadLimit       uint     `json:"scproxy_read_limit" mapstructure:"scproxy-read-limit"`
+	ScproxyWriteLimit      uint     `json:"scproxy_write_limit" mapstructure:"scproxy-write-limit"`
+	SePort                 int      `json:"se_port" mapstructure:"se-port"`
+	SharedTunnel           bool     `json:"shared_tunnel_flag" mapstructure:"shared-tunnel"`
+	TunnelCainfo           string   `json:"tunnel_cainfo" mapstructure:"tunnel-cainfo"`
+	TunnelCapath           string   `json:"tunnel_capath" mapstructure:"tunnel-capath"`
+	TunnelCert             string   `json:"tunnel_cert" mapstructure:"tunnel-cert"`
+	TunnelCertSuffix       string   `json:"tunnel_cert_suffix" mapstructure:"tunnel-cert-suffix"`
+	TunnelDomains          []string `json:"tunnel_domains" mapstructure:"tunnel-domains"`
+	TunnelIdentifier       string   `json:"tunnel_identifier" mapstructure:"tunnel-identifier"`
+	PoolSize               int32    `json:"pool_size" mapstructure:"pool-size"`
+	VeryVerbose            bool     `json:"very_verbose" mapstructure:"very-verbose"`
 }

--- a/manager/tunnel.go
+++ b/manager/tunnel.go
@@ -1,0 +1,4 @@
+package manager
+
+type tunnel struct {
+}


### PR DESCRIPTION
Struct to convert a yaml/toml file to a TunnelArgs struct has been added.  This will NOT represent a live tunnel.  This is only to represent the args passed in via the config file.

Additional work is needed to move the `manager.TunnelArgs` into an actual `Tunnel` struct.